### PR TITLE
styles: hide main menu and instruments on non-desktop devices

### DIFF
--- a/frontend/src/components/Home/index.js
+++ b/frontend/src/components/Home/index.js
@@ -15,6 +15,7 @@ import {
   renderInstrumentItem,
   remapInstrumentsData
 } from "../../utils/instruments.utils";
+import "./styles.scss";
 
 const Home = () => {
   const [selectedPage, setSelectedPage] = useState(null);
@@ -63,7 +64,7 @@ const Home = () => {
           }
         />
       </div>
-      <div className="container">
+      <div className="container pages-list">
         <List columns={3}>
           {data.map(doc => (
             <ListItem
@@ -78,16 +79,8 @@ const Home = () => {
       </div>
 
       <div className="container">
-        <div className="columns">
-          <div className="column is-8">
-            {selectedPage && (
-              <ContentPage
-                page={selectedPage}
-                subPage={selectedSubPage}
-              ></ContentPage>
-            )}
-          </div>
-          <aside className="column is-4">
+        <div className="columns homepage-columns">
+          <aside className="column is-4 homepage-sidebar">
             <SidebarMenu>
               {data.map(doc => {
                 let menuItems = null;
@@ -125,15 +118,25 @@ const Home = () => {
               })}
             </SidebarMenu>
 
-            <Hero title={"Instrumente utile"} useFallbackIcon={true} />
-            <Instruments layout="column">
-              {Object.keys(instrumentsData).map(category => {
-                return instrumentsData[category].map(usefulApp =>
-                  renderInstrumentItem(usefulApp)
-                );
-              })}
-            </Instruments>
+            <div className="instruments-wrapper">
+              <Hero title={"Instrumente utile"} useFallbackIcon={true} />
+              <Instruments layout="column">
+                {Object.keys(instrumentsData).map(category => {
+                  return instrumentsData[category].map(usefulApp =>
+                    renderInstrumentItem(usefulApp)
+                  );
+                })}
+              </Instruments>
+            </div>
           </aside>
+          <div className="column is-8">
+            {selectedPage && (
+              <ContentPage
+                page={selectedPage}
+                subPage={selectedSubPage}
+              ></ContentPage>
+            )}
+          </div>
         </div>
       </div>
     </>

--- a/frontend/src/components/Home/styles.scss
+++ b/frontend/src/components/Home/styles.scss
@@ -1,0 +1,12 @@
+@media (min-width: 768px) {
+  .homepage-columns {
+    flex-direction: row-reverse;
+  }
+}
+
+@media (max-width: 768px) {
+  .homepage-sidebar .instruments-wrapper,
+  .pages-list {
+    display: none;
+  }
+}


### PR DESCRIPTION
### What changed?
- Changed order for the "Navigare rapida" section on mobile (It's displayed before the content)
- Hide main menu and "Instrumente utile" section on tablet and mobile.
